### PR TITLE
Adds types to package.json export definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "./dist/vue-error-boundary.es.js",
   "exports": {
     ".": {
+      "types": "./dist/src/VErrorBoundary.d.ts",
       "import": "./dist/vue-error-boundary.es.js",
       "require": "./dist/vue-error-boundary.umd.js"
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-error-boundary",
   "author": "Dillon Chanis <dillonchanis92@gmail.com> (http://dillonchanis.com/)",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A reusable error boundary component for catching JavaScript errors and displaying fallback UIs.",
   "files": [
     "dist"


### PR DESCRIPTION
We have a frontend monorepo and due to how the tsconfig and vite config is setup we are getting issues where the types do not exist in the export so the builds fail type checks. For example:

```
vue-tsc --noEmit && vite build

src/ErrorBoundary.vue:10:28 - error TS7016: Could not find a declaration file for module 'vue-error-boundary'. '/Users/ollie/Repos/easyagvsystem/Source/FleetControllerFrontend/node_modules/vue-error-boundary/dist/vue-error-boundary.es.js' implicitly has an 'any' type.
  There are types at '/Users/ollie/Repos/easyagvsystem/Source/FleetControllerFrontend/node_modules/vue-error-boundary/dist/src/VErrorBoundary.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-error-boundary' library may need to update its package.json or typings.

10 import VErrorBoundary from 'vue-error-boundary';
                              ~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/ErrorBoundary.vue:10

npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
```

This commit adds the support required with no breaking changes for anything else as it still refers to the same type definitions as defined in the `"types"` property and increments a version bump.